### PR TITLE
Remove temporary include

### DIFF
--- a/avalanche.cpp
+++ b/avalanche.cpp
@@ -1,4 +1,3 @@
-#include "sys/cdefs.h"
 #include <algorithm>
 #include "dem.h"
 #include "raster.h"


### PR DESCRIPTION
Causes build failure on windows